### PR TITLE
feat: add model metadata to LLM responses

### DIFF
--- a/examples/history.py
+++ b/examples/history.py
@@ -14,9 +14,10 @@ prompt = [
 
 
 async def main():
-    response = stream_llm(prompt)
+    response = await stream_llm(prompt)
     async for r in response:
         print(r, end="", flush=True)
+    print()
 
 
 if __name__ == "__main__":

--- a/examples/llm_func.py
+++ b/examples/llm_func.py
@@ -7,7 +7,8 @@ from smolllm import LLMFunction, ask_llm
 custom_llm_with_args = partial(
     ask_llm,
     api_key="pollinations_dont_need_api_key",
-    model="openai/openai-large",
+    # GET https://text.pollinations.ai/models
+    model="openai/openai-fast",
     base_url="https://text.pollinations.ai/openai#",
 )
 
@@ -17,7 +18,11 @@ def translate(llm: LLMFunction, text: str, to: str = "Chinese"):
 
 
 async def main():
-    print(await translate(custom_llm_with_args, "Show me the money"))
+    response = await translate(custom_llm_with_args, "Show me the money")
+    print(f"response: {response}")
+    print(f"model: {response.model}")
+    print(f"model_name: {response.model_name}")
+    print(f"provider: {response.provider}")
 
 
 if __name__ == "__main__":

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -8,7 +8,7 @@ load_dotenv()
 
 
 async def main(prompt: str = "Say hello world in a creative way"):
-    response = stream_llm(
+    response = await stream_llm(
         prompt,
         # model="gemini/gemini-2.0-flash",  # specify model can override env.SMOLLLM_MODEL
         # model=[
@@ -16,8 +16,11 @@ async def main(prompt: str = "Say hello world in a creative way"):
         #     "gemini/gemini-2.5-flash-preview-05-20",
         # ],
     )
+    # response is now a StreamResponse object with model info
+    print(f"Streaming from model: {response.model}")
     async for r in response:
         print(r, end="", flush=True)
+    print()  # New line after streaming
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
 ]
 test = [
     "pytest>=8.3.5",
+    "pytest-asyncio>=1.1.0",
 ]
 
 [tool.ruff.lint]

--- a/src/smolllm/__init__.py
+++ b/src/smolllm/__init__.py
@@ -3,7 +3,15 @@ smolllm - A minimal LLM library for easy interaction with various LLM providers
 """
 
 from .core import ask_llm, stream_llm
-from .types import LLMFunction, Message, MessageRole, PromptType, StreamHandler
+from .types import (
+    LLMFunction,
+    LLMResponse,
+    Message,
+    MessageRole,
+    PromptType,
+    StreamHandler,
+    StreamResponse,
+)
 
 __version__ = "0.3.1"
 __all__ = [
@@ -14,4 +22,6 @@ __all__ = [
     "PromptType",
     "Message",
     "MessageRole",
+    "LLMResponse",
+    "StreamResponse",
 ]

--- a/src/smolllm/types.py
+++ b/src/smolllm/types.py
@@ -1,5 +1,7 @@
+from dataclasses import dataclass
 from typing import (
     Any,
+    AsyncIterator,
     Awaitable,
     Callable,
     Dict,
@@ -10,10 +12,53 @@ from typing import (
     Union,
 )
 
+
+@dataclass
+class LLMResponse:
+    """Response from LLM with metadata about which model was used"""
+
+    text: str
+    # e.g. "gemini/gemini-2.0-flash"
+    model: str
+    # e.g. "gemini-2.0-flash"
+    model_name: str
+    # e.g. gemini
+    provider: Optional[str] = None
+
+    def __str__(self) -> str:
+        """Allow str() conversion for backwards compatibility"""
+        return self.text
+
+    def __bool__(self) -> bool:
+        """Check if response has content"""
+        return bool(self.text and self.text.strip())
+
+
+@dataclass
+class StreamResponse:
+    """Wrapper for streaming responses with model metadata"""
+
+    stream: AsyncIterator[str]
+    # e.g. "openrouter/google/gemini-2.5-flash"
+    model: str
+    # e.g. "gemini-2.5-flash"
+    model_name: str
+    # e.g. openrouter
+    provider: Optional[str] = None
+
+    def __aiter__(self):
+        """Return self to make this a proper async iterator"""
+        return self
+
+    async def __anext__(self):
+        """Forward to underlying stream"""
+        return await self.stream.__anext__()
+
+
 StreamHandler: TypeAlias = Callable[[str], None]
 LLMFunction: TypeAlias = Callable[
-    [str, Optional[str], Any], Awaitable[str]
-]  # (prompt, system_prompt, **kwargs) -> response
+    [str, Optional[str], Any], Awaitable[LLMResponse]
+]  # (prompt, system_prompt, **kwargs) -> LLMResponse
 
 MessageRole = Literal["user", "assistant"]
 Message = Dict[str, Union[str, List[Dict[str, Any]]]]

--- a/uv.lock
+++ b/uv.lock
@@ -404,6 +404,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -514,6 +526,7 @@ dev = [
 ]
 test = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -521,6 +534,7 @@ requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2.2" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.5" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.1.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "rich", specifier = ">=13.9.4" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=4.0.2" },


### PR DESCRIPTION
This commit introduces `LLMResponse` and `StreamResponse` classes to include model and provider information in the responses from `ask_llm` and `stream_llm` functions. This allows users to easily identify which model was used for a given response. Additionally, examples are updated to display the new model attributes and print a newline after streaming. Finally, the commit adds pytest-asyncio for testing asynchronous code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responses now return structured objects for non-streaming and streaming, surfaced with model and provider metadata and exported for user access.

* **Refactor**
  * Streaming API now returns a stream wrapper and must be awaited before async iteration; non-streaming calls return structured responses.

* **Documentation**
  * Examples updated to await streaming calls, print response metadata, and ensure output ends with a trailing newline.

* **Chores**
  * Added pytest-asyncio to test/dev dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->