### PR TITLE
feat(metrics): mark estimated token counts with ~, add e2e usage tests

### DIFF
--- a/src/smolllm/core.py
+++ b/src/smolllm/core.py
@@ -250,7 +250,9 @@ async def ask_llm(
                 response_text=resp + reasoning,
             )
 
-            logger.info(format_metrics(model_name, input_tokens, output_tokens, total_time, ttft_ms))
+            logger.info(
+                format_metrics(model_name, input_tokens, output_tokens, total_time, ttft_ms, estimated=estimated)
+            )
 
             usage = Usage(
                 provider=provider.name,
@@ -437,7 +439,11 @@ async def stream_llm(
                     ttft_ms: int | None = None
                     if first_token_time is not None:
                         ttft_ms = max(0, int((first_token_time - start_time) * 1000))
-                    logger.info(format_metrics(model_name, input_tokens, output_tokens, total_time, ttft_ms))
+                    logger.info(
+                        format_metrics(
+                            model_name, input_tokens, output_tokens, total_time, ttft_ms, estimated=estimated
+                        )
+                    )
                 else:
                     raise StreamError("Stream completed without content")
 

--- a/src/smolllm/metrics.py
+++ b/src/smolllm/metrics.py
@@ -12,6 +12,8 @@ def format_metrics(
     output_tokens: int,
     total_time: float,
     ttft_ms: int | None = None,
+    *,
+    estimated: bool = True,
 ) -> str:
     """Format metrics for logging with emojis.
 
@@ -21,6 +23,7 @@ def format_metrics(
         output_tokens: Number of output tokens
         total_time: Total time in seconds
         ttft_ms: Time to first token in milliseconds (optional, for streaming)
+        estimated: Whether token counts are heuristic estimates (shown with ~)
 
     Returns:
         Formatted metrics string with emojis
@@ -28,7 +31,8 @@ def format_metrics(
     total_tokens = input_tokens + output_tokens
     tok_per_sec = int(output_tokens / total_time) if total_time > 0 else 0
 
-    metrics = f"📊{model_name} {total_tokens}tok (↑{input_tokens} ↓{output_tokens})"
+    approx = "~" if estimated else ""
+    metrics = f"📊{model_name} {approx}{total_tokens}tok (↑{input_tokens} ↓{output_tokens})"
     if ttft_ms is not None:
         metrics += f" | 🚀{_format_time(ttft_ms)}"
 

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,0 +1,132 @@
+"""End-to-end usage reporting through the public API (mocked transport)."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+import smolllm.core as core
+from smolllm.core import ask_llm, stream_llm
+
+MODEL = "testprov/m1"
+BASE_URL = "http://test.local/v1"
+
+
+def _install_transport(monkeypatch: pytest.MonkeyPatch, handler) -> None:
+    def fake_prepare(url: str, api_key: str) -> httpx.AsyncClient:
+        return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    monkeypatch.setattr(core, "prepare_client_and_auth", fake_prepare)
+
+
+def _sse(*chunks: dict[str, object]) -> bytes:
+    lines = [f"data: {json.dumps(c)}\n\n" for c in chunks]
+    lines.append("data: [DONE]\n\n")
+    return "".join(lines).encode()
+
+
+@pytest.mark.asyncio
+async def test_ask_llm_non_stream_uses_reported_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "model": "m1",
+                "choices": [{"message": {"content": "hello"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 12, "completion_tokens": 34},
+            },
+        )
+
+    _install_transport(monkeypatch, handler)
+    resp = await ask_llm("hi", model=MODEL, api_key="k", base_url=BASE_URL, stream=False)
+    assert resp.text == "hello"
+    assert resp.usage is not None
+    assert resp.usage.estimated is False
+    assert (resp.usage.input_tokens, resp.usage.output_tokens) == (12, 34)
+
+
+@pytest.mark.asyncio
+async def test_ask_llm_stream_uses_final_usage_chunk(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = _sse(
+        {"model": "m1", "choices": [{"delta": {"content": "hel"}, "finish_reason": None}]},
+        {"choices": [{"delta": {"content": "lo"}, "finish_reason": "stop"}]},
+        {"choices": [], "usage": {"prompt_tokens": 12, "completion_tokens": 34}},
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert b"include_usage" in request.content
+        return httpx.Response(200, content=body)
+
+    _install_transport(monkeypatch, handler)
+    resp = await ask_llm("hi", model=MODEL, api_key="k", base_url=BASE_URL)
+    assert resp.text == "hello"
+    assert resp.usage is not None
+    assert resp.usage.estimated is False
+    assert (resp.usage.input_tokens, resp.usage.output_tokens) == (12, 34)
+
+
+@pytest.mark.asyncio
+async def test_ask_llm_stream_without_usage_falls_back_to_estimate(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = _sse({"model": "m1", "choices": [{"delta": {"content": "hello"}, "finish_reason": "stop"}]})
+    _install_transport(monkeypatch, lambda request: httpx.Response(200, content=body))
+    resp = await ask_llm("hi", model=MODEL, api_key="k", base_url=BASE_URL)
+    assert resp.usage is not None
+    assert resp.usage.estimated is True
+
+
+@pytest.mark.asyncio
+async def test_ask_llm_retries_400_without_stream_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[bytes] = []
+    body = _sse({"model": "m1", "choices": [{"delta": {"content": "hello"}, "finish_reason": "stop"}]})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.content)
+        if b"stream_options" in request.content:
+            return httpx.Response(400, json={"error": {"message": "unknown field stream_options"}})
+        return httpx.Response(200, content=body)
+
+    _install_transport(monkeypatch, handler)
+    resp = await ask_llm("hi", model=MODEL, api_key="k", base_url=BASE_URL)
+    assert resp.text == "hello"
+    assert len(calls) == 2
+    assert b"stream_options" not in calls[1]
+    assert resp.usage is not None
+    assert resp.usage.estimated is True
+
+
+@pytest.mark.asyncio
+async def test_stream_llm_uses_final_usage_chunk(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = _sse(
+        {"model": "m1", "choices": [{"delta": {"content": "hel"}, "finish_reason": None}]},
+        {"choices": [{"delta": {"content": "lo"}, "finish_reason": "stop"}]},
+        {"choices": [], "usage": {"prompt_tokens": 12, "completion_tokens": 34}},
+    )
+    _install_transport(monkeypatch, lambda request: httpx.Response(200, content=body))
+    resp = await stream_llm("hi", model=MODEL, api_key="k", base_url=BASE_URL)
+    text = "".join([chunk.content async for chunk in resp])
+    assert text == "hello"
+    assert resp.usage is not None
+    assert resp.usage.estimated is False
+    assert (resp.usage.input_tokens, resp.usage.output_tokens) == (12, 34)
+
+
+@pytest.mark.asyncio
+async def test_stream_llm_retries_400_without_stream_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[bytes] = []
+    body = _sse({"model": "m1", "choices": [{"delta": {"content": "hello"}, "finish_reason": "stop"}]})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.content)
+        if b"stream_options" in request.content:
+            return httpx.Response(400, json={"error": {"message": "unknown field stream_options"}})
+        return httpx.Response(200, content=body)
+
+    _install_transport(monkeypatch, handler)
+    resp = await stream_llm("hi", model=MODEL, api_key="k", base_url=BASE_URL)
+    text = "".join([chunk.content async for chunk in resp])
+    assert text == "hello"
+    assert len(calls) == 2
+    assert resp.usage is not None
+    assert resp.usage.estimated is True


### PR DESCRIPTION
## Superseded & rebased

The original PR implemented provider-reported usage parsing — then the (previously unpushed) 2026-07-04 work landed on main as 42e3f69 with the same feature and a cleaner core split. Rebased onto main; this PR is now only the delta main lacks:

- **`format_metrics` gains `estimated` kwarg** — heuristic totals log as `~Ntok` (e.g. `📊fast ~37tok`), provider-reported ones without the `~`, so the two are distinguishable at a glance. Both core call sites pass the flag.
- **`tests/test_usage.py`** — end-to-end MockTransport coverage through the public `ask_llm`/`stream_llm` API (main's new tests stop at the `http_stream`/`request` unit level): reported usage on stream + non-stream, estimate fallback, and the 400 `stream_options` retry observed from the caller's side.

## Verification

- 132 tests pass (6 new).
- Live smoke on this branch: `deepseek/deepseek-chat` → `estimated=False in=10 out=2`.
- Known gap unchanged: smolserver (:11435) emits no SSE usage chunk, so proxied calls stay `estimated=True` until smolllm-go/server gain support.